### PR TITLE
Reformat/redisign the Docker image creation.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM nginx:latest
 
-ENV BOUNCA_VERSION=102483429 \
+ARG BOUNCA_FILE_VERSION=102483429
+
+ENV BOUNCA_FILE_VERSION=${BOUNCA_FILE_VERSION} \
     DOCROOT=/srv/www/bounca \
     LOGDIR=/var/log/bounca \
     ETCDIR=/etc/bounca \
@@ -16,7 +18,7 @@ RUN apt-get update && \
     gettext netcat-traditional nginx python3 python3-dev python3-setuptools \
     python-is-python3 uwsgi uwsgi-plugin-python3 virtualenv python3-virtualenv \
     python3-pip wget ca-certificates openssl python3-psycopg2 net-tools && \
-    wget -P /srv/www --content-disposition https://gitlab.com/bounca/bounca/-/package_files/${BOUNCA_VERSION}/download && \
+    wget -P /srv/www --content-disposition https://gitlab.com/bounca/bounca/-/package_files/${BOUNCA_FILE_VERSION}/download && \
     tar -xzvf /srv/www/bounca.tar.gz -C /srv/www && \
     rm /srv/www/bounca.tar.gz && \
     mkdir -pv ${LOGDIR} ${DOCROOT} ${ETCDIR} /etc/nginx/sites-available /etc/nginx/sites-enabled && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM --platform=$BUILDPLATFORM golang:1.21 as build
+FROM nginx:latest
 
-ARG TARGETPLATFORM
-#RUN echo "nameserver 192.168.11.1" > /etc/resolv.conf
-
-FROM nginx:1.25.3-bookworm
-ENV DOCROOT=/srv/www/bounca \
+ENV BOUNCA_VERSION=102483429 \
+    DOCROOT=/srv/www/bounca \
     LOGDIR=/var/log/bounca \
     ETCDIR=/etc/bounca \
     UWSGIDIR=/etc/uwsgi \
@@ -12,40 +9,34 @@ ENV DOCROOT=/srv/www/bounca \
     BOUNCA_USER=www-data \
     BOUNCA_GROUP=www-data
 
-RUN apt-get update \
-  && apt-get install -qy \
-    gettext netcat-traditional nginx python3 python3-dev python3-setuptools python-is-python3 uwsgi uwsgi-plugin-python3 virtualenv python3-virtualenv python3-pip \
-    wget ca-certificates openssl \
-  && apt-get install -qy python3-psycopg2
+COPY files/bounca-config.sh /docker-entrypoint.d/bounca-config.sh
 
-RUN wget -P /srv/www --content-disposition https://gitlab.com/bounca/bounca/-/package_files/102483429/download \
-  && tar -xzvf /srv/www/bounca.tar.gz -C /srv/www \
-  && rm /srv/www/bounca.tar.gz
-
-RUN mkdir -pv ${LOGDIR} ${DOCROOT} ${ETCDIR} /etc/nginx/sites-available /etc/nginx/sites-enabled \
-  && rm -fv /etc/nginx/conf.d/default.conf \
-  && rmdir /etc/nginx/conf.d \
-  && ln -s /etc/nginx/sites-enabled /etc/nginx/conf.d \
-  && cp -v ${DOCROOT}/etc/nginx/bounca /etc/nginx/sites-available/bounca.conf \
-  && ln -s /etc/nginx/sites-available/bounca.conf /etc/nginx/sites-enabled/bounca.conf \
-  && cp -v ${DOCROOT}/etc/uwsgi/bounca.ini /etc/uwsgi/apps-available/bounca.ini \
-  && ln -s /etc/uwsgi/apps-available/bounca.ini /etc/uwsgi/apps-enabled/bounca.ini \
-  && chown -R ${BOUNCA_USER}:${BOUNCA_GROUP} ${LOGDIR} ${DOCROOT} ${ETCDIR} ${UWSGIDIR} ${NGINXDIR} \
-  && chown ${BOUNCA_USER}:${BOUNCA_GROUP} /var/run /var/cache/nginx
-
-
-RUN sed -i '/psycopg2-binary/d' ${DOCROOT}/requirements.txt
-
-RUN pip install --no-cache-dir --break-system-packages -r ${DOCROOT}/requirements.txt
-
-RUN ln -sfT /dev/stdout "/var/log/nginx/bounca-access.log" \
-  && ln -sfT /dev/stdout "/var/log/nginx/bounca-error.log" \
-  && apt-get clean \
-  && rm -rfv /tmp/* /var/tmp/* /var/lib/apt/lists/* ${DOCROOT}/.git \
-  ;
-
-COPY files/ /docker-entrypoint.d/
+RUN apt-get update && \
+    apt-get install -qy \
+    gettext netcat-traditional nginx python3 python3-dev python3-setuptools \
+    python-is-python3 uwsgi uwsgi-plugin-python3 virtualenv python3-virtualenv \
+    python3-pip wget ca-certificates openssl python3-psycopg2 net-tools && \
+    wget -P /srv/www --content-disposition https://gitlab.com/bounca/bounca/-/package_files/${BOUNCA_VERSION}/download && \
+    tar -xzvf /srv/www/bounca.tar.gz -C /srv/www && \
+    rm /srv/www/bounca.tar.gz && \
+    mkdir -pv ${LOGDIR} ${DOCROOT} ${ETCDIR} /etc/nginx/sites-available /etc/nginx/sites-enabled && \
+    rm -fv /etc/nginx/conf.d/default.conf && \
+    rmdir /etc/nginx/conf.d && \
+    ln -s /etc/nginx/sites-enabled /etc/nginx/conf.d && \
+    cp -v ${DOCROOT}/etc/nginx/bounca /etc/nginx/sites-available/bounca.conf && \
+    ln -s /etc/nginx/sites-available/bounca.conf /etc/nginx/sites-enabled/bounca.conf && \
+    cp -v ${DOCROOT}/etc/uwsgi/bounca.ini /etc/uwsgi/apps-available/bounca.ini && \
+    ln -s /etc/uwsgi/apps-available/bounca.ini /etc/uwsgi/apps-enabled/bounca.ini && \
+    chown -R ${BOUNCA_USER}:${BOUNCA_GROUP} ${LOGDIR} ${DOCROOT} ${ETCDIR} ${UWSGIDIR} ${NGINXDIR} && \
+    chown ${BOUNCA_USER}:${BOUNCA_GROUP} /var/run /var/cache/nginx && \
+    sed -i '/psycopg2-binary/d' ${DOCROOT}/requirements.txt && \
+    pip install --no-cache-dir --break-system-packages -r ${DOCROOT}/requirements.txt && \
+    chmod +x /docker-entrypoint.d/bounca-config.sh && \
+    ln -sfT /dev/stdout "/var/log/nginx/bounca-access.log" && \
+    ln -sfT /dev/stdout "/var/log/nginx/bounca-error.log" && \
+    apt-get clean && \
+    rm -rfv /tmp/* /var/tmp/* /var/lib/apt/lists/* ${DOCROOT}/.git
 
 WORKDIR ${DOCROOT}
 
-VOLUME ${DOCROOT}
+EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,20 +17,19 @@ RUN apt-get update && \
     apt-get install -qy \
       gettext netcat-traditional nginx python3 python3-dev python3-setuptools \
       python-is-python3 uwsgi uwsgi-plugin-python3 python3-pip \
-      wget ca-certificates openssl python3-psycopg2 net-tools && \
-    mkdir -pv ${LOGDIR} ${DOCROOT} ${ETCDIR} /etc/nginx/sites-available /etc/nginx/sites-enabled /srv/www && \
+      wget ca-certificates openssl python3-psycopg2 && \
+    mkdir -pv ${LOGDIR} ${DOCROOT} ${ETCDIR} /etc/nginx/sites-available /etc/nginx/sites-enabled && \
     wget -P /tmp --content-disposition https://gitlab.com/bounca/bounca/-/package_files/${BOUNCA_FILE_VERSION}/download && \
     tar -xzvf /tmp/bounca.tar.gz -C /srv/www && \
     pip install --no-cache-dir --break-system-packages -r ${DOCROOT}/requirements.txt && \
-    rm -fv /etc/nginx/conf.d/default.conf && \
-    rmdir /etc/nginx/conf.d && \
+    rm -rfv /etc/nginx/conf.d && \
     ln -s /etc/nginx/sites-enabled /etc/nginx/conf.d && \
     cp -v ${DOCROOT}/etc/nginx/bounca /etc/nginx/sites-available/bounca.conf && \
     ln -s /etc/nginx/sites-available/bounca.conf /etc/nginx/sites-enabled/bounca.conf && \
     cp -v ${DOCROOT}/etc/uwsgi/bounca.ini /etc/uwsgi/apps-available/bounca.ini && \
     ln -s /etc/uwsgi/apps-available/bounca.ini /etc/uwsgi/apps-enabled/bounca.ini && \
-    chown -R ${BOUNCA_USER}:${BOUNCA_GROUP} ${LOGDIR} ${DOCROOT} ${ETCDIR} ${UWSGIDIR} ${NGINXDIR} \
-      /var/run /var/cache/nginx && \
+    chown -R ${BOUNCA_USER}:${BOUNCA_GROUP} ${LOGDIR} ${DOCROOT} ${ETCDIR} ${UWSGIDIR} \
+      ${NGINXDIR} /var/run /var/cache/nginx && \
     sed -i '/psycopg2-binary/d' ${DOCROOT}/requirements.txt && \
     chmod +x /docker-entrypoint.d/bounca-config.sh && \
     ln -sfT /dev/stdout "/var/log/nginx/bounca-access.log" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,13 @@ COPY files/bounca-config.sh /docker-entrypoint.d/bounca-config.sh
 
 RUN apt-get update && \
     apt-get install -qy \
-    gettext netcat-traditional nginx python3 python3-dev python3-setuptools \
-    python-is-python3 uwsgi uwsgi-plugin-python3 virtualenv python3-virtualenv \
-    python3-pip wget ca-certificates openssl python3-psycopg2 net-tools && \
-    wget -P /srv/www --content-disposition https://gitlab.com/bounca/bounca/-/package_files/${BOUNCA_FILE_VERSION}/download && \
-    tar -xzvf /srv/www/bounca.tar.gz -C /srv/www && \
-    rm /srv/www/bounca.tar.gz && \
-    mkdir -pv ${LOGDIR} ${DOCROOT} ${ETCDIR} /etc/nginx/sites-available /etc/nginx/sites-enabled && \
+      gettext netcat-traditional nginx python3 python3-dev python3-setuptools \
+      python-is-python3 uwsgi uwsgi-plugin-python3 python3-pip \
+      wget ca-certificates openssl python3-psycopg2 net-tools && \
+    mkdir -pv ${LOGDIR} ${DOCROOT} ${ETCDIR} /etc/nginx/sites-available /etc/nginx/sites-enabled /srv/www && \
+    wget -P /tmp --content-disposition https://gitlab.com/bounca/bounca/-/package_files/${BOUNCA_FILE_VERSION}/download && \
+    tar -xzvf /tmp/bounca.tar.gz -C /srv/www && \
+    pip install --no-cache-dir --break-system-packages -r ${DOCROOT}/requirements.txt && \
     rm -fv /etc/nginx/conf.d/default.conf && \
     rmdir /etc/nginx/conf.d && \
     ln -s /etc/nginx/sites-enabled /etc/nginx/conf.d && \
@@ -29,10 +29,9 @@ RUN apt-get update && \
     ln -s /etc/nginx/sites-available/bounca.conf /etc/nginx/sites-enabled/bounca.conf && \
     cp -v ${DOCROOT}/etc/uwsgi/bounca.ini /etc/uwsgi/apps-available/bounca.ini && \
     ln -s /etc/uwsgi/apps-available/bounca.ini /etc/uwsgi/apps-enabled/bounca.ini && \
-    chown -R ${BOUNCA_USER}:${BOUNCA_GROUP} ${LOGDIR} ${DOCROOT} ${ETCDIR} ${UWSGIDIR} ${NGINXDIR} && \
-    chown ${BOUNCA_USER}:${BOUNCA_GROUP} /var/run /var/cache/nginx && \
+    chown -R ${BOUNCA_USER}:${BOUNCA_GROUP} ${LOGDIR} ${DOCROOT} ${ETCDIR} ${UWSGIDIR} ${NGINXDIR} \
+      /var/run /var/cache/nginx && \
     sed -i '/psycopg2-binary/d' ${DOCROOT}/requirements.txt && \
-    pip install --no-cache-dir --break-system-packages -r ${DOCROOT}/requirements.txt && \
     chmod +x /docker-entrypoint.d/bounca-config.sh && \
     ln -sfT /dev/stdout "/var/log/nginx/bounca-access.log" && \
     ln -sfT /dev/stdout "/var/log/nginx/bounca-error.log" && \

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ docker run --rm -d --name postgres --network=net-bounca --network-alias=postgres
 docker run -p 8080:8080 --rm -dit -e BOUNCA_FQDN=localhost --name bounca --network=net-bounca -e DB_PWD=bounca aluveitie/bounca:latest
 ```
 
+### Using docker-compose
+
+```
+docker-compose up -d
+```
+
 Access it on http://localhost:8080 and sign up to create your admin user
 
 ## How to build yourself
@@ -28,7 +34,7 @@ Access it on http://localhost:8080 and sign up to create your admin user
 # Multi platform to your prefered registry
 docker buildx build --platform=linux/arm64,linux/amd64 --file Dockerfile --push .
 
-# Single platform to run in local docker 
+# Single platform to run in local docker
 docker buildx build --platform=linux/arm64 --file Dockerfile -t bounca:latest --load .
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+---
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    networks:
+      bounca:
+        aliases:
+          - postgres
+    volumes:
+      - <PATH_TO_POSTGRES_DATA>:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=<POSTGRES_PASSWORD>
+      - POSTGRES_USER=<POSTGRES_USER>
+      - POSTGRES_DB=<POSTGRES_DB>
+
+  bounca:
+    image: bounca:latest
+    networks:
+      - bounca
+      - default
+    ports:
+      - 8080:8080
+    environment:
+      - BOUNCA_FQDN=<FQDN>
+      - BOUNCA_DJANGO_SECRET=<DJANGO_SECRET>
+      - POSTGRES_HOST=<POSTGRES_HOST>
+      - POSTGRES_PORT=5432
+      - POSTGRES_PASSWORD=<POSTGRES_PASSWORD>
+      - POSTGRES_USER=<POSTGRES_USER>
+      - POSTGRES_DB=<POSTGRES_DB>
+      - DJANGO_SUPERUSER_NAME=<SUPERUSER_NAME>
+      - DJANGO_SUPERUSER_PASSWORD=<SUPERUSER_PASSWORD>
+      - DJANGO_SUPERUSER_EMAIL=<SUPERUSER_EMAIL>
+      - SMTP_HOST=<SMTP_HOST>
+      - SMTP_PORT=<SMTP_PORT>
+      - SMTP_USER=<SMTP_USER>
+      - SMTP_PASSWORD=<SMTP_PASSWORD>
+      - SMTP_CONNECTION=<SMTP_CONNECTION>
+      - FROM_EMAIL=<FROM_EMAIL>
+
+networks:
+  bounca:
+    internal: true

--- a/files/bounca-config.sh
+++ b/files/bounca-config.sh
@@ -77,7 +77,7 @@ if [ -n "${DJANGO_SUPERUSER_PASSWORD}" ]; then
   python3 manage.py createsuperuser \
     --noinput \
     --username "${DJANGO_SUPERUSER_NAME:-superuser}" \
-    --email "${DJANGO_SUPERUSER_EMAIL:-superuser@example.com}"
+    --email "${DJANGO_SUPERUSER_EMAIL:-superuser@example.com}" >/dev/null || true
 fi
 
 # Remove the home parameter which was set to use virtual env in default configuration

--- a/files/bounca-config.sh
+++ b/files/bounca-config.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
 PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin
 CONFIG_FILE=/etc/bounca/services.yaml
@@ -11,13 +12,13 @@ if [[ ! -f ${CONFIG_FILE} ]]; then
     echo "...generating random BOUNCA_DJANGO_SECRET."
   fi
 
-  echo "
+  cat <<EOF >${CONFIG_FILE}
 psql:
-  dbname: ${DB_NAME:-bounca}
-  username: ${DB_USER:-bounca}
-  password: ${DB_PWD:-bounca}
-  host: ${DB_HOST:-postgres}
-  port: ${DB_PORT:-5432}
+  dbname: ${POSTGRES_DB:-bounca}
+  username: ${POSTGRES_USER:-bounca}
+  password: ${POSTGRES_PASSWORD:-bounca}
+  host: ${POSTGRES_HOST:-postgres}
+  port: ${POSTGRES_PORT:-5432}
 
 admin:
   enabled: True
@@ -35,31 +36,32 @@ django:
 mail:
   host: ${SMTP_HOST:-localhost}
   port: ${SMTP_PORT:-25}
-  #username: ${SMTP_USERNAME:-}
-  #password: ${SMTP_PASSWORD:-}
+  username: ${SMTP_USER:-}
+  password: ${SMTP_PASSWORD:-}
   connection: ${SMTP_CONNECTION:-none}
-  admin: ${ADMIN_MAIL:-admin@example.com}
-  from: ${FROM_MAIL:-no-reply@example.com}
+  admin: ${DJANGO_SUPERUSER_EMAIL:-admin@example.com}
+  from: ${FROM_EMAIL:-no-reply@example.com}
 
 certificate-engine:
-  # allowed values: ed25519, rsa
-  # Ed25519 is a a modern, fast and safe key algorithm, however not supported by all operating systems, like MacOS.
-  # Keep the 'rsa' option if unsure. Root and intermediate keys are 4096 bits, client and server certificates
-  # use 2048 bits keys.
   key_algorithm: rsa
 
 registration:
-  # allowed values: mandatory, optional, off
-  email_verification: off" > ${CONFIG_FILE}
+  email_verification: off
+EOF
 fi
 
-# netcat test PSQL
-if [ "$(nc -zv "${DB_HOST:-postgres}" "${DB_PORT:-5432}"; echo $?)" -ne 0 ]; then
-  echo "${DB_HOST:-postgres} PSQL server is not reachable on port ${DB_PORT:-5432}"
-  exit 1
-fi
+# wait for postgres
+while true; do
+  if nc -zv "${POSTGRES_HOST:-postgres}" "${POSTGRES_PORT:-5432}" > /dev/null; then
+    echo "${POSTGRES_HOST:-postgres} PSQL server is reachable on port ${POSTGRES_PORT:-5432}. Let's go!"
+    break
+  else
+    echo "${POSTGRES_HOST:-postgres} PSQL server is not reachable on port ${POSTGRES_PORT:-5432}. Waiting..."
+    sleep 3
+  fi
+done
 
-cd "${DOCROOT}" && pwd
+# cd "${DOCROOT}"
 python3 manage.py migrate
 python3 manage.py collectstatic
 
@@ -68,6 +70,14 @@ if [ -z "${BOUNCA_FQDN+x}" ]; then
   exit 1
 elif [[ -n "${BOUNCA_FQDN}" ]]; then
   python3 manage.py site "${BOUNCA_FQDN}"
+fi
+
+# Create Django Superuser
+if [ -n "${DJANGO_SUPERUSER_PASSWORD}" ]; then
+  python3 manage.py createsuperuser \
+    --noinput \
+    --username "${DJANGO_SUPERUSER_NAME:-superuser}" \
+    --email "${DJANGO_SUPERUSER_EMAIL:-superuser@example.com}"
 fi
 
 # Remove the home parameter which was set to use virtual env in default configuration


### PR DESCRIPTION
Thanks for your work! This is exactly what I was searching for. 

A few changes to your dockerisation of BounCA:

### Changes to `Dockerfile`:
- Prepare the building for automation. (Still waiting for https://gitlab.com/gitlab-org/gitlab/-/issues/421976 to be able to get the latest package).
- Reformat layers to save some space on the image (FYI: every `RUN` creates a new layer. If in one later you pull a file and in another layer you delete it, this doesn't change the size of the final image. Do all such operations within the same layer). This reformat saves almost 100MB in image size.

### Changes to `bounca-config.sh`:
- Wait for Postgres to become available instead of quitting bounca when it is not available.
- Create `Django Superuser` when `DJANGO_SUPERUSER_PASSWORD` is specified.
- Rename/unify variables.