### PR TITLE
fix(docker-entry): Add 'noinput' flag to collectstatic

### DIFF
--- a/files/bounca-config.sh
+++ b/files/bounca-config.sh
@@ -63,7 +63,7 @@ done
 
 # cd "${DOCROOT}"
 python3 manage.py migrate
-python3 manage.py collectstatic
+python3 manage.py collectstatic --noinput
 
 if [ -z "${BOUNCA_FQDN+x}" ]; then
   echo "BOUNCA_FQDN variable should be defined but is not, exiting..." >/dev/stderr


### PR DESCRIPTION
Since the user is not always available to access the container's terminal, the 'noinput' flag should be added to collectstatic.