### PR TITLE
Move port change to the build step.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && \
     ln -s /etc/nginx/sites-enabled /etc/nginx/conf.d && \
     cp -v ${DOCROOT}/etc/nginx/bounca /etc/nginx/sites-available/bounca.conf && \
     ln -s /etc/nginx/sites-available/bounca.conf /etc/nginx/sites-enabled/bounca.conf && \
+    sed -i 's#80#8080#g' /etc/nginx/sites-available/bounca.conf && \ # Set non-default port
     cp -v ${DOCROOT}/etc/uwsgi/bounca.ini /etc/uwsgi/apps-available/bounca.ini && \
     ln -s /etc/uwsgi/apps-available/bounca.ini /etc/uwsgi/apps-enabled/bounca.ini && \
     sed -i 's/www-data/nginx/g' /etc/uwsgi/apps-available/bounca.ini && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && \
     ln -s /etc/nginx/sites-enabled /etc/nginx/conf.d && \
     cp -v ${DOCROOT}/etc/nginx/bounca /etc/nginx/sites-available/bounca.conf && \
     ln -s /etc/nginx/sites-available/bounca.conf /etc/nginx/sites-enabled/bounca.conf && \
-    sed -i 's#80#8080#g' /etc/nginx/sites-available/bounca.conf && \ # Set non-default port
+    sed -i 's#80#8080#g' /etc/nginx/sites-available/bounca.conf && \
     cp -v ${DOCROOT}/etc/uwsgi/bounca.ini /etc/uwsgi/apps-available/bounca.ini && \
     ln -s /etc/uwsgi/apps-available/bounca.ini /etc/uwsgi/apps-enabled/bounca.ini && \
     sed -i 's/www-data/nginx/g' /etc/uwsgi/apps-available/bounca.ini && \

--- a/files/bounca-config.sh
+++ b/files/bounca-config.sh
@@ -84,9 +84,6 @@ fi
 sed -i '/^home/d' /etc/uwsgi/apps-enabled/bounca.ini
 sed -i 's#chmod-socket = 700#chmod-socket = 777#g' /etc/uwsgi/apps-enabled/bounca.ini
 
-# Set non-default port
-sed -i 's#80#8080#g' /etc/nginx/sites-available/bounca.conf
-
 # Check Nginx config
 nginx -t
 


### PR DESCRIPTION
The `bounca-config.sh` file is executed on every start/restart so the nginx config grows with every restart making the service inaccessible.